### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/mydbr/extensions/geo/geolocation.php
+++ b/mydbr/extensions/geo/geolocation.php
@@ -5,7 +5,7 @@ function Geo_GetLoc($ipaddress)
 
   $data = array();
   $license_key=$geo_license_key;
-  $query = "http://geoip1.maxmind.com/f?l=" . $license_key . "&i=" . $ipaddress;
+  $query = "https://geoip.maxmind.com/f?l=" . $license_key . "&i=" . $ipaddress;
   $url = parse_url($query);
   $host = $url["host"];
   $path = $url["path"] . "?" . $url["query"];


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)